### PR TITLE
Refine evaluation context and collector wiring

### DIFF
--- a/src/main/java/dev/evalfluxx/evaluation/DefaultEvaluationConfiguration.java
+++ b/src/main/java/dev/evalfluxx/evaluation/DefaultEvaluationConfiguration.java
@@ -1,0 +1,40 @@
+package dev.evalfluxx.evaluation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Default in-memory configuration backing for evaluations.
+ */
+public class DefaultEvaluationConfiguration implements EvaluationConfiguration {
+
+    private final String id;
+    private final String name;
+    private final Map<String, String> settings;
+
+    public DefaultEvaluationConfiguration(String id, String name, Map<String, String> settings) {
+        this.id = id == null ? "default" : id;
+        this.name = name == null ? this.id : name;
+        this.settings = settings == null ? Collections.emptyMap() : new HashMap<>(settings);
+    }
+
+    public static DefaultEvaluationConfiguration empty(String id, String name) {
+        return new DefaultEvaluationConfiguration(id, name, Collections.emptyMap());
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public Map<String, String> settings() {
+        return Collections.unmodifiableMap(settings);
+    }
+}

--- a/src/main/java/dev/evalfluxx/evaluation/DefaultEvaluationContext.java
+++ b/src/main/java/dev/evalfluxx/evaluation/DefaultEvaluationContext.java
@@ -1,0 +1,29 @@
+package dev.evalfluxx.evaluation;
+
+import java.util.Objects;
+
+/**
+ * Default implementation of an evaluation context.
+ */
+public class DefaultEvaluationContext implements EvaluationContext {
+
+    private final EvaluationConfiguration configuration;
+    private final EvaluationResultCollector resultCollector;
+
+    public DefaultEvaluationContext(EvaluationConfiguration configuration, EvaluationResultCollector resultCollector) {
+        this.configuration = Objects.requireNonNull(configuration, "configuration");
+        Objects.requireNonNull(resultCollector, "resultCollector");
+        EvaluationResultCollectorHolder.register(resultCollector);
+        this.resultCollector = EvaluationResultCollectorHolder.getInstance();
+    }
+
+    @Override
+    public EvaluationConfiguration configuration() {
+        return configuration;
+    }
+
+    @Override
+    public EvaluationResultCollector resultCollector() {
+        return resultCollector;
+    }
+}

--- a/src/main/java/dev/evalfluxx/evaluation/Evaluation.java
+++ b/src/main/java/dev/evalfluxx/evaluation/Evaluation.java
@@ -1,0 +1,19 @@
+package dev.evalfluxx.evaluation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as an evaluation entry point that should be executed by the default runner.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Evaluation {
+
+    /**
+     * Optional custom name for the evaluation. If empty, the method name is used instead.
+     */
+    String value() default "";
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationConfiguration.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationConfiguration.java
@@ -1,0 +1,35 @@
+package dev.evalfluxx.evaluation;
+
+import java.util.Map;
+
+/**
+ * Configuration used by {@link EvaluationRunner} instances to decide which evaluation
+ * settings should be executed.
+ */
+public interface EvaluationConfiguration {
+
+    /**
+     * @return stable identifier of the configuration (e.g. file name, profile id)
+     */
+    String id();
+
+    /**
+     * @return human readable name of the configuration
+     */
+    String name();
+
+    /**
+     * @return immutable view of configuration settings
+     */
+    Map<String, String> settings();
+
+    /**
+     * Convenience method to access individual configuration values.
+     *
+     * @param key configuration key
+     * @return configuration value or {@code null} when undefined
+     */
+    default String get(String key) {
+        return settings().get(key);
+    }
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationContext.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationContext.java
@@ -1,0 +1,16 @@
+package dev.evalfluxx.evaluation;
+
+/**
+ * Context passed to evaluation sets that bundles configuration and the result collector.
+ */
+public interface EvaluationContext extends EvaluationResultCollector {
+
+    EvaluationConfiguration configuration();
+
+    EvaluationResultCollector resultCollector();
+
+    @Override
+    default void record(EvaluationRecord record) {
+        resultCollector().record(record);
+    }
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationException.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationException.java
@@ -1,0 +1,15 @@
+package dev.evalfluxx.evaluation;
+
+/**
+ * Exception that signals problems during evaluation execution.
+ */
+public class EvaluationException extends Exception {
+
+    public EvaluationException(String message) {
+        super(message);
+    }
+
+    public EvaluationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationRecord.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationRecord.java
@@ -1,0 +1,34 @@
+package dev.evalfluxx.evaluation;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Captures a single measurement that has been produced during evaluation.
+ */
+public record EvaluationRecord(String runnerName, String evaluationSetName, String metricName, Object value,
+                               EvaluationConfiguration configuration, Instant timestamp,
+                               Map<String, String> attributes) {
+
+    public EvaluationRecord {
+        configuration = configuration == null
+                ? DefaultEvaluationConfiguration.empty("", "")
+                : configuration;
+        if (timestamp == null) {
+            timestamp = Instant.now();
+        }
+        attributes = attributes == null ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(attributes));
+    }
+
+    public String configurationId() {
+        return Objects.toString(configuration.id(), "");
+    }
+
+    public String configurationName() {
+        String name = configuration.name();
+        return name == null ? configurationId() : name;
+    }
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationResultCollector.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationResultCollector.java
@@ -1,0 +1,14 @@
+package dev.evalfluxx.evaluation;
+
+/**
+ * Abstraction used by evaluations to propagate measured values to a central system.
+ */
+public interface EvaluationResultCollector {
+
+    /**
+     * Record a single measurement.
+     *
+     * @param record measurement record produced by an evaluation
+     */
+    void record(EvaluationRecord record);
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationResultCollectorHolder.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationResultCollectorHolder.java
@@ -1,0 +1,69 @@
+package dev.evalfluxx.evaluation;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Simple holder to expose the active {@link EvaluationResultCollector} as a singleton service for evaluations.
+ */
+public final class EvaluationResultCollectorHolder implements EvaluationResultCollector {
+
+    private static final EvaluationResultCollectorHolder INSTANCE = new EvaluationResultCollectorHolder();
+    private static final List<EvaluationResultCollector> COLLECTORS = new CopyOnWriteArrayList<>();
+
+    private EvaluationResultCollectorHolder() {
+    }
+
+    public static EvaluationResultCollectorHolder getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Register a collector instance that should receive evaluation results.
+     */
+    public static void register(EvaluationResultCollector collector) {
+        Objects.requireNonNull(collector, "collector");
+        if (collector == INSTANCE) {
+            return;
+        }
+        if (!COLLECTORS.contains(collector)) {
+            COLLECTORS.add(collector);
+        }
+    }
+
+    /**
+     * Remove a collector that should no longer receive evaluation results.
+     */
+    public static void unregister(EvaluationResultCollector collector) {
+        COLLECTORS.remove(collector);
+    }
+
+    /**
+     * Obtain a broadcasting collector that forwards records to every registered collector.
+     */
+    public static Optional<EvaluationResultCollector> get() {
+        if (COLLECTORS.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(INSTANCE);
+    }
+
+    /**
+     * Forward a record to all registered collectors.
+     */
+    @Override
+    public void record(EvaluationRecord record) {
+        for (EvaluationResultCollector collector : COLLECTORS) {
+            collector.record(record);
+        }
+    }
+
+    /**
+     * @return immutable snapshot of currently registered collectors
+     */
+    public static List<EvaluationResultCollector> collectors() {
+        return List.copyOf(COLLECTORS);
+    }
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationRunner.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationRunner.java
@@ -1,0 +1,37 @@
+package dev.evalfluxx.evaluation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Loads the evaluation configuration and exposes the evaluation sets that should be executed.
+ */
+public interface EvaluationRunner {
+
+    /**
+     * @return human readable name of the runner
+     */
+    default String getName() {
+        return getClass().getSimpleName();
+    }
+
+    /**
+     * @return evaluation configurations that this runner will execute
+     */
+    default Collection<EvaluationConfiguration> getConfigurations() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Load configuration that determines how this runner executes.
+     *
+     * @param configuration evaluation configuration
+     * @throws EvaluationException when the configuration cannot be processed
+     */
+    void loadConfiguration(EvaluationConfiguration configuration) throws EvaluationException;
+
+    /**
+     * @return evaluation sets managed by this runner
+     */
+    Collection<EvaluationSet> getEvaluationSets();
+}

--- a/src/main/java/dev/evalfluxx/evaluation/EvaluationSet.java
+++ b/src/main/java/dev/evalfluxx/evaluation/EvaluationSet.java
@@ -1,0 +1,20 @@
+package dev.evalfluxx.evaluation;
+
+/**
+ * Represents a collection of evaluation steps that belong together.
+ */
+public interface EvaluationSet {
+
+    /**
+     * @return human readable name of the evaluation set
+     */
+    String getName();
+
+    /**
+     * Execute the evaluation set using the provided context.
+     *
+     * @param context evaluation context
+     * @throws EvaluationException when evaluation cannot be completed
+     */
+    void execute(EvaluationContext context) throws EvaluationException;
+}

--- a/src/main/java/dev/evalfluxx/evaluation/Evaluator.java
+++ b/src/main/java/dev/evalfluxx/evaluation/Evaluator.java
@@ -1,0 +1,86 @@
+package dev.evalfluxx.evaluation;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base implementation of an {@link EvaluationRunner} that turns annotated methods into {@link EvaluationSet}s.
+ */
+public abstract class Evaluator implements EvaluationRunner {
+
+    private final List<EvaluationSet> evaluationSets = new ArrayList<>();
+    private EvaluationConfiguration configuration;
+
+    @Override
+    public void loadConfiguration(EvaluationConfiguration configuration) throws EvaluationException {
+        evaluationSets.clear();
+        this.configuration = configuration;
+        for (Method method : getEvaluationMethods()) {
+            evaluationSets.add(createEvaluationSet(method));
+        }
+    }
+
+    @Override
+    public Collection<EvaluationConfiguration> getConfigurations() {
+        return configuration == null ? Collections.emptyList() : Collections.singletonList(configuration);
+    }
+
+    @Override
+    public Collection<EvaluationSet> getEvaluationSets() {
+        return Collections.unmodifiableList(evaluationSets);
+    }
+
+    private List<Method> getEvaluationMethods() {
+        List<Method> methods = new ArrayList<>();
+        for (Method method : getClass().getMethods()) {
+            if (method.isAnnotationPresent(Evaluation.class)) {
+                methods.add(method);
+            }
+        }
+        return methods;
+    }
+
+    private EvaluationSet createEvaluationSet(Method method) {
+        Evaluation annotation = method.getAnnotation(Evaluation.class);
+        String name = annotation.value().isEmpty() ? method.getName() : annotation.value();
+        return new MethodBackedEvaluationSet(this, method, name);
+    }
+
+    private static final class MethodBackedEvaluationSet implements EvaluationSet {
+        private final Evaluator target;
+        private final Method method;
+        private final String name;
+
+        MethodBackedEvaluationSet(Evaluator target, Method method, String name) {
+            this.target = target;
+            this.method = method;
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public void execute(EvaluationContext context) throws EvaluationException {
+            try {
+                method.setAccessible(true);
+                Class<?>[] parameterTypes = method.getParameterTypes();
+                if (parameterTypes.length == 0) {
+                    method.invoke(target);
+                } else if (parameterTypes.length == 1 && EvaluationContext.class.isAssignableFrom(parameterTypes[0])) {
+                    method.invoke(target, context);
+                } else {
+                    throw new EvaluationException("Unsupported parameter signature for evaluation method: " + method);
+                }
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new EvaluationException("Failed to execute evaluation method: " + method, e);
+            }
+        }
+    }
+}

--- a/src/main/java/dev/evalfluxx/mojo/EvalFluxXMojo.java
+++ b/src/main/java/dev/evalfluxx/mojo/EvalFluxXMojo.java
@@ -1,10 +1,24 @@
 package dev.evalfluxx.mojo;
 
+import dev.evalfluxx.evaluation.DefaultEvaluationConfiguration;
+import dev.evalfluxx.evaluation.DefaultEvaluationContext;
+import dev.evalfluxx.evaluation.EvaluationConfiguration;
+import dev.evalfluxx.evaluation.EvaluationContext;
+import dev.evalfluxx.evaluation.EvaluationException;
+import dev.evalfluxx.evaluation.EvaluationRunner;
+import dev.evalfluxx.evaluation.EvaluationSet;
+import dev.evalfluxx.evaluation.EvaluationResultCollector;
+import dev.evalfluxx.evaluation.EvaluationResultCollectorHolder;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.ServiceLoader;
 
 /**
  * Mojo that will be bound to the custom rag-evaluation lifecycle phase.
@@ -20,6 +34,49 @@ public class EvalFluxXMojo extends AbstractMojo {
     }
 
     private void performEvaluation() {
-        // TODO later evaluation logic
+        EvaluationResultCollectorHolder collectorHolder = EvaluationResultCollectorHolder.getInstance();
+        ServiceLoader<EvaluationResultCollector> collectorLoader = ServiceLoader.load(EvaluationResultCollector.class,
+                Thread.currentThread().getContextClassLoader());
+        Iterator<EvaluationResultCollector> collectorIterator = collectorLoader.iterator();
+        while (collectorIterator.hasNext()) {
+            EvaluationResultCollectorHolder.register(collectorIterator.next());
+        }
+        MavenLogEvaluationResultCollector mavenLogCollector = new MavenLogEvaluationResultCollector(getLog());
+        EvaluationResultCollectorHolder.register(mavenLogCollector);
+
+        ServiceLoader<EvaluationRunner> loader = ServiceLoader.load(EvaluationRunner.class,
+                Thread.currentThread().getContextClassLoader());
+        boolean foundRunner = false;
+        for (EvaluationRunner runner : loader) {
+            foundRunner = true;
+            getLog().info("Executing EvaluationRunner: " + runner.getName());
+            try {
+                EvaluationConfiguration defaultConfiguration = DefaultEvaluationConfiguration.empty("default", "Default");
+                runner.loadConfiguration(defaultConfiguration);
+                Collection<EvaluationConfiguration> configurations = runner.getConfigurations();
+                if (configurations.isEmpty()) {
+                    configurations = Collections.singletonList(defaultConfiguration);
+                }
+
+                for (EvaluationConfiguration configuration : configurations) {
+                    EvaluationContext context = new DefaultEvaluationContext(configuration, collectorHolder);
+                    Collection<EvaluationSet> evaluationSets = runner.getEvaluationSets();
+                    if (evaluationSets.isEmpty()) {
+                        getLog().warn("EvaluationRunner returned no EvaluationSets: " + runner.getName());
+                    }
+                    for (EvaluationSet evaluationSet : evaluationSets) {
+                        getLog().info("Executing EvaluationSet: " + evaluationSet.getName()
+                                + " with configuration " + configuration.name() + " (" + configuration.id() + ")");
+                        evaluationSet.execute(context);
+                    }
+                }
+            } catch (EvaluationException e) {
+                getLog().error("EvaluationRunner failed: " + runner.getName(), e);
+            }
+        }
+
+        if (!foundRunner) {
+            getLog().warn("No EvaluationRunner implementations found on the classpath.");
+        }
     }
 }

--- a/src/main/java/dev/evalfluxx/mojo/MavenLogEvaluationResultCollector.java
+++ b/src/main/java/dev/evalfluxx/mojo/MavenLogEvaluationResultCollector.java
@@ -1,0 +1,24 @@
+package dev.evalfluxx.mojo;
+
+import dev.evalfluxx.evaluation.EvaluationRecord;
+import dev.evalfluxx.evaluation.EvaluationResultCollector;
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * Simple collector that forwards evaluation measurements to the Maven build log.
+ */
+public class MavenLogEvaluationResultCollector implements EvaluationResultCollector {
+
+    private final Log log;
+
+    public MavenLogEvaluationResultCollector(Log log) {
+        this.log = log;
+    }
+
+    @Override
+    public void record(EvaluationRecord record) {
+        log.info("[Evaluation] " + record.runnerName() + "/" + record.evaluationSetName()
+                 + " [" + record.configurationName() + " (" + record.configurationId() + ")" + "] - "
+                 + record.metricName() + "=" + record.value() + " " + record.attributes());
+    }
+}


### PR DESCRIPTION
## Summary
- make the evaluation context an EvaluationResultCollector that forwards records
- carry full EvaluationConfiguration in EvaluationRecord while deriving id/name helpers
- broadcast records through the holder, loading collectors via ServiceLoader and wiring contexts to the shared holder

## Testing
- mvn -q -DskipTests compile *(fails: unable to resolve maven-plugin-plugin:3.13.1 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f4c86aec832fa465ca3369d4ceba)