### PR TITLE
Clarify evaluator location and discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,38 @@ mvn verify
 ```
 
 Das Goal `evalfluxx:run` wird in beiden Fällen im Rahmen der neuen Phase `rag-evaluation` ausgeführt.
+
+### Beispiel: Eigener `Evaluator` mit `@Evaluation`
+
+Erweitere den `Evaluator` und markiere Evaluationsmethoden mit `@Evaluation`:
+
+```java
+import dev.evalfluxx.evaluation.*;
+import java.time.Instant;
+import java.util.Map;
+
+public class GreetingEvaluator extends Evaluator {
+
+    @Evaluation("greeting-check")
+    public void evaluateGreeting(EvaluationContext context) {
+        String expectedGreeting = (String) context.configuration()
+                .settings()
+                .getOrDefault("expectedGreeting", "Hello, EvalFluxX!");
+
+        boolean greetingPresent = expectedGreeting.startsWith("Hello");
+
+        context.resultCollector().record(new EvaluationRecord(
+                getClass().getSimpleName(),
+                "greeting-check",
+                "greeting-present",
+                greetingPresent,
+                context.configuration(),
+                Instant.now(),
+                Map.of("source", "integration-test", "greeting", expectedGreeting))
+        );
+    }
+}
+```
+
+Lege den Evaluator z. B. unter `src/evaluation/java` ab. Bei `mvn rag-evaluation` oder innerhalb
+von `mvn verify` wird er über den `ServiceLoader` automatisch entdeckt und ausgeführt.


### PR DESCRIPTION
## Summary
- point readers to place custom evaluator classes under `src/evaluation/java`
- simplify usage instructions by noting automatic ServiceLoader discovery without manual registration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934956bb0b8832f8652cbe75922e064)